### PR TITLE
Simplify the ViewModel Factory boilerplate code.

### DIFF
--- a/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/application/injection/SingletonComponent.kt
+++ b/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/application/injection/SingletonComponent.kt
@@ -30,7 +30,7 @@ interface SingletonComponent {
     fun authenticationManager(): AuthenticationManager
 
     fun loginViewModelFactory(): LoginViewModel.VmFactory.Factory
-    fun registrationViewModelFactory(): RegistrationViewModel.VmFactory.Factory
+    fun registrationViewModelFactory(): RegistrationViewModel.Factory
     fun profileViewModelFactory(): ProfileViewModel.VmFactory
 
     @Component.Factory

--- a/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/registration/CreateLoginCredentialsFragment.kt
+++ b/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/registration/CreateLoginCredentialsFragment.kt
@@ -16,24 +16,21 @@
 package com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.features.registration
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.observe
 import androidx.navigation.Navigation
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.R
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.application.injection.Injector
-import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.databinding.CreateLoginCredentialsFragmentBinding
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.core.events.observe
+import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.databinding.CreateLoginCredentialsFragmentBinding
+import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.navGraphViewModel
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.onClick
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.onTextChanged
 
 
 class CreateLoginCredentialsFragment : Fragment(R.layout.create_login_credentials_fragment) {
-    private lateinit var viewModel: RegistrationViewModel
 
     val backPressListener = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
@@ -41,28 +38,9 @@ class CreateLoginCredentialsFragment : Fragment(R.layout.create_login_credential
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // see https://twitter.com/Zhuinden/status/1255204348067483648
-        if(!::viewModel.isInitialized) { // cannot retrieve in `onCreate` because `NavController` is not ready (to get the NavGraph entry)
-            // solution: move this logic to execute once in `onCreateView` as that is the only callback directly after onCreate()
-            val navController = Navigation.findNavController(requireActivity(), R.id.nav_host)
-            val navGraphBackstackEntry = navController.getBackStackEntry(R.id.registration_graph)
-
-            viewModel = ViewModelProvider(
-                navGraphBackstackEntry,
-                Injector.get()
-                    .registrationViewModelFactory()
-                    .createFactory(navGraphBackstackEntry, arguments ?: Bundle())
-            ).get(RegistrationViewModel::class.java)
-        }
-
-        return super.onCreateView(inflater, container, savedInstanceState)
+    private val viewModel by navGraphViewModel(R.id.registration_graph) { handle ->
+        Injector.get().registrationViewModelFactory().create(handle)
     }
-
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/registration/EnterProfileDataFragment.kt
+++ b/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/registration/EnterProfileDataFragment.kt
@@ -16,51 +16,29 @@
 package com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.features.registration
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.observe
 import androidx.navigation.Navigation
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.R
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.application.injection.Injector
-import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.databinding.EnterProfileDataFragmentBinding
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.core.events.observe
+import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.databinding.EnterProfileDataFragmentBinding
+import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.navGraphViewModel
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.onClick
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.onTextChanged
 
 
 class EnterProfileDataFragment : Fragment(R.layout.enter_profile_data_fragment) {
-    private lateinit var viewModel: RegistrationViewModel
-
     val backPressListener = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             viewModel.onBackEvent()
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // can't be in `onCreate()`, see https://twitter.com/Zhuinden/status/1255204348067483648
-        if (!::viewModel.isInitialized) { // cannot retrieve in `onCreate` because `NavController` is not ready (to get the NavGraph entry)
-            // solution: move this logic to execute once in `onCreateView` as that is the only callback directly after onCreate()
-            val navController = Navigation.findNavController(requireActivity(), R.id.nav_host)
-            val navGraphBackstackEntry = navController.getBackStackEntry(R.id.registration_graph)
-
-            viewModel = ViewModelProvider(
-                navGraphBackstackEntry,
-                Injector.get()
-                    .registrationViewModelFactory()
-                    .createFactory(navGraphBackstackEntry, arguments ?: Bundle())
-            ).get(RegistrationViewModel::class.java)
-        }
-
-        return super.onCreateView(inflater, container, savedInstanceState)
+    private val viewModel by navGraphViewModel(R.id.registration_graph) { handle ->
+        Injector.get().registrationViewModelFactory().create(handle)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/registration/RegistrationViewModel.kt
+++ b/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/registration/RegistrationViewModel.kt
@@ -15,9 +15,10 @@
  */
 package com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.features.registration
 
-import android.os.Bundle
-import androidx.lifecycle.*
-import androidx.savedstate.SavedStateRegistryOwner
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.zhuinden.eventemitter.EventEmitter
@@ -27,30 +28,10 @@ import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.applic
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.core.navigation.NavigationCommand
 import com.zhuinden.livedatacombinetuplekt.combineTuple
 
-class RegistrationViewModel(
+class RegistrationViewModel @AssistedInject constructor(
     private val authenticationManager: AuthenticationManager,
-    private val savedStateHandle: SavedStateHandle
+    @Assisted private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
-    class VmFactory @AssistedInject constructor(
-        private val authenticationManager: AuthenticationManager,
-        @Assisted savedStateRegistryOwner: SavedStateRegistryOwner,
-        @Assisted defaultArgs: Bundle
-    ) : AbstractSavedStateViewModelFactory(savedStateRegistryOwner, defaultArgs) {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(
-            key: String,
-            modelClass: Class<T>,
-            savedStateHandle: SavedStateHandle
-        ): T = RegistrationViewModel(authenticationManager, savedStateHandle) as T
-
-        @AssistedInject.Factory // https://github.com/square/AssistedInject/issues/141
-        interface Factory {
-            fun createFactory(
-                savedStateRegistryOwner: SavedStateRegistryOwner,
-                defaultArgs: Bundle
-            ): VmFactory
-        }
-    }
 
     private val navigationEmitter: EventEmitter<NavigationCommand> = EventEmitter()
     val navigationCommands: EventSource<NavigationCommand> get() = navigationEmitter
@@ -103,5 +84,12 @@ class RegistrationViewModel(
         navigationEmitter.emit { navController, context ->
             navController.popBackStack()
         }
+    }
+
+    @AssistedInject.Factory
+    interface Factory {
+        fun create(
+            savedStateHandle: SavedStateHandle
+        ): RegistrationViewModel
     }
 }


### PR DESCRIPTION
I've tried to simplify the way you create the RegistrationViewModel, and created some utility methods that would help to do that. I think that simplifies the sample greatly. 