### PR TITLE
Make observing LiveData more readable

### DIFF
--- a/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/profile/ProfileFragment.kt
@@ -25,6 +25,7 @@ import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.R
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.application.injection.Injector
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.core.events.observe
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.fragmentViewModels
+import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.observe
 
 class ProfileFragment: Fragment(R.layout.profile_fragment) {
     private val viewModel by fragmentViewModels {
@@ -40,6 +41,6 @@ class ProfileFragment: Fragment(R.layout.profile_fragment) {
             navigationCommand(Navigation.findNavController(view), requireContext())
         }
 
-        viewModel.activationCheck.observe(viewLifecycleOwner) {}
+        observe(viewModel.activationCheck) {}
     }
 }

--- a/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/registration/CreateLoginCredentialsFragment.kt
+++ b/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/registration/CreateLoginCredentialsFragment.kt
@@ -26,6 +26,7 @@ import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.applic
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.core.events.observe
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.databinding.CreateLoginCredentialsFragmentBinding
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.navGraphSavedStateViewModels
+import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.observe
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.onClick
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.onTextChanged
 
@@ -45,7 +46,7 @@ class CreateLoginCredentialsFragment : Fragment(R.layout.create_login_credential
             textUsername.onTextChanged { username -> viewModel.username.value = username }
             textPassword.onTextChanged { password -> viewModel.password.value = password }
 
-            viewModel.isRegisterAndLoginEnabled.observe(viewLifecycleOwner) { enabled ->
+            observe(viewModel.isRegisterAndLoginEnabled) { enabled ->
                 buttonRegisterAndLogin.isEnabled = enabled
             }
             buttonRegisterAndLogin.onClick { viewModel.onRegisterAndLoginClicked() }

--- a/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/registration/EnterProfileDataFragment.kt
+++ b/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/features/registration/EnterProfileDataFragment.kt
@@ -25,6 +25,7 @@ import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.applic
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.core.events.observe
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.databinding.EnterProfileDataFragmentBinding
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.navGraphSavedStateViewModels
+import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.observe
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.onClick
 import com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils.onTextChanged
 
@@ -44,7 +45,7 @@ class EnterProfileDataFragment : Fragment(R.layout.enter_profile_data_fragment) 
             textFullName.onTextChanged { fullName -> viewModel.fullName.value = fullName }
             textBio.onTextChanged { bio -> viewModel.bio.value = bio }
 
-            viewModel.isEnterProfileNextEnabled.observe(viewLifecycleOwner) { enabled ->
+            observe(viewModel.isEnterProfileNextEnabled) { enabled ->
                 buttonEnterProfileNext.isEnabled = enabled
             }
             buttonEnterProfileNext.onClick { viewModel.onEnterProfileNextClicked() }

--- a/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/utils/LiveDataUtils.kt
+++ b/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/utils/LiveDataUtils.kt
@@ -17,7 +17,6 @@ package com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 
@@ -25,7 +24,7 @@ import androidx.lifecycle.Observer
  * Utils to observe liveData in a cleaner way from an Activity.
  */
 inline fun <T> AppCompatActivity.observe(liveData: LiveData<T>, crossinline observer: (T) -> Unit) {
-    observeLifeCycle(liveData, observer)
+    liveData.observe(this, Observer { observer(it) })
 }
 
 /**
@@ -35,7 +34,12 @@ inline fun <T> AppCompatActivity.observeOnce(
     liveData: LiveData<T>,
     crossinline observer: (T) -> Unit
 ) {
-    observeLifeCycleOnce(liveData, observer)
+    liveData.observe(this, object : Observer<T> {
+        override fun onChanged(t: T) {
+            liveData.removeObserver(this)
+            observer(t)
+        }
+    })
 }
 
 /**
@@ -45,7 +49,7 @@ inline fun <T> AppCompatActivity.observeOnce(
  * being tied to the enclosing Fragment's lifecycle
  */
 inline fun <T> Fragment.observe(liveData: LiveData<T>, crossinline observer: (T) -> Unit) {
-    viewLifecycleOwner.observeLifeCycle(liveData, observer)
+    liveData.observe(viewLifecycleOwner, Observer { observer(it) })
 }
 
 /**
@@ -55,31 +59,7 @@ inline fun <T> Fragment.observe(liveData: LiveData<T>, crossinline observer: (T)
  * being tied to the enclosing Fragment's lifecycle
  */
 inline fun <T> Fragment.observeOnce(liveData: LiveData<T>, crossinline observer: (T) -> Unit) {
-    viewLifecycleOwner.observeLifeCycleOnce(liveData, observer)
-}
-
-/**
- * Utils to observe liveData in a cleaner way from any LifecycleOwner.
- *
- * This should not be used with Fragment as lifecycleOwner
- */
-inline fun <T> LifecycleOwner.observeLifeCycle(
-    liveData: LiveData<T>,
-    crossinline observer: (T) -> Unit
-) {
-    liveData.observe(this, Observer { observer(it) })
-}
-
-/**
- * Utils to observe a liveData FOR ONE VALUE in a cleaner way from any LifecycleOwner.
- *
- * This should not be used with Fragment as lifecycleOwner
- */
-inline fun <T> LifecycleOwner.observeLifeCycleOnce(
-    liveData: LiveData<T>,
-    crossinline observer: (T) -> Unit
-) {
-    liveData.observe(this, object : Observer<T> {
+    liveData.observe(viewLifecycleOwner, object : Observer<T> {
         override fun onChanged(t: T) {
             liveData.removeObserver(this)
             observer(t)

--- a/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/utils/LiveDataUtils.kt
+++ b/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/utils/LiveDataUtils.kt
@@ -15,22 +15,74 @@
  */
 package com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils
 
-import androidx.annotation.MainThread
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 
-@MainThread
-inline fun <T> LiveData<T>.observeOnce(
-    owner: LifecycleOwner,
-    crossinline onChanged: (T) -> Unit
-): Observer<T> {
-    val wrappedObserver = object : Observer<T> {
+/**
+ * Utils to observe liveData in a cleaner way from an Activity.
+ */
+inline fun <T> AppCompatActivity.observe(liveData: LiveData<T>, crossinline observer: (T) -> Unit) {
+    observeLifeCycle(liveData, observer)
+}
+
+/**
+ * Utils to observe a liveData FOR ONE VALUE in a cleaner way from an Activity.
+ */
+inline fun <T> AppCompatActivity.observeOnce(
+    liveData: LiveData<T>,
+    crossinline observer: (T) -> Unit
+) {
+    observeLifeCycleOnce(liveData, observer)
+}
+
+/**
+ * Utils to observe liveData in a cleaner and safe way from a Fragment.
+ *
+ * It enforces observing viewLifecycleOwner to avoid bugs due to Fragments' view lifecycle not
+ * being tied to the enclosing Fragment's lifecycle
+ */
+inline fun <T> Fragment.observe(liveData: LiveData<T>, crossinline observer: (T) -> Unit) {
+    viewLifecycleOwner.observeLifeCycle(liveData, observer)
+}
+
+/**
+ * Utils to observe a liveData FOR ONE VALUE in a cleaner and safe way from a Fragment.
+ *
+ * It enforces observing viewLifecycleOwner to avoid bugs due to Fragments' view lifecycle not
+ * being tied to the enclosing Fragment's lifecycle
+ */
+inline fun <T> Fragment.observeOnce(liveData: LiveData<T>, crossinline observer: (T) -> Unit) {
+    viewLifecycleOwner.observeLifeCycleOnce(liveData, observer)
+}
+
+/**
+ * Utils to observe liveData in a cleaner way from any LifecycleOwner.
+ *
+ * This should not be used with Fragment as lifecycleOwner
+ */
+inline fun <T> LifecycleOwner.observeLifeCycle(
+    liveData: LiveData<T>,
+    crossinline observer: (T) -> Unit
+) {
+    liveData.observe(this, Observer { observer(it) })
+}
+
+/**
+ * Utils to observe a liveData FOR ONE VALUE in a cleaner way from any LifecycleOwner.
+ *
+ * This should not be used with Fragment as lifecycleOwner
+ */
+inline fun <T> LifecycleOwner.observeLifeCycleOnce(
+    liveData: LiveData<T>,
+    crossinline observer: (T) -> Unit
+) {
+    liveData.observe(this, object : Observer<T> {
         override fun onChanged(t: T) {
-            removeObserver(this)
-            onChanged.invoke(t)
+            liveData.removeObserver(this)
+            observer(t)
         }
-    }
-    observe(owner, wrappedObserver)
-    return wrappedObserver
+    })
 }


### PR DESCRIPTION
I do not like how LiveData is observed and I've also found a lot of people using `this` as lifecycleOwner in fragments. 
I did these extension functions to solve the first and reduce the likelihood of the second.
If you like them the same mechanism could be applied to your EventSource.observe.