### PR TITLE
Simplify ViewModel extensions

### DIFF
--- a/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/utils/ViewModelUtils.kt
+++ b/app/src/main/java/com/zhuinden/jetpacknavigationdaggersavedstatehandleftueexperiment/utils/ViewModelUtils.kt
@@ -13,68 +13,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("UNCHECKED_CAST")
+
 package com.zhuinden.jetpacknavigationdaggersavedstatehandleftueexperiment.utils
 
-import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.createViewModelLazy
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.navigation.fragment.findNavController
-import androidx.savedstate.SavedStateRegistryOwner
-
-inline fun <reified T : ViewModel> SavedStateRegistryOwner.createAbstractSavedStateViewModelFactory(
-    arguments: Bundle,
-    crossinline creator: (SavedStateHandle) -> T
-): ViewModelProvider.Factory {
-    return object : AbstractSavedStateViewModelFactory(this, arguments) {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel?> create(
-            key: String, modelClass: Class<T>, handle: SavedStateHandle
-        ): T = creator(handle) as T
-    }
-}
+import androidx.navigation.navGraphViewModels
 
 inline fun <reified T : ViewModel> Fragment.navGraphSavedStateViewModels(
     @IdRes navGraphId: Int,
-    crossinline creator: (SavedStateHandle) -> T
-): Lazy<T> {
-    // Wrapped in lazy to not search the NavController each time we want the backStackEntry
-    val backStackEntry by lazy { findNavController().getBackStackEntry(navGraphId) }
-
-    return createViewModelLazy(T::class, storeProducer = {
-        backStackEntry.viewModelStore
-    }, factoryProducer = {
-        backStackEntry.createAbstractSavedStateViewModelFactory(
-            arguments = backStackEntry.arguments ?: Bundle(), creator = creator
-        )
-    })
+    crossinline viewModelProducer: (SavedStateHandle) -> T
+) = navGraphViewModels<T>(navGraphId) {
+    object : AbstractSavedStateViewModelFactory(this, arguments) {
+        override fun <T : ViewModel> create(
+            key: String, modelClass: Class<T>, handle: SavedStateHandle
+        ) = viewModelProducer(handle) as T
+    }
 }
 
 inline fun <reified T : ViewModel> Fragment.fragmentSavedStateViewModels(
-    crossinline creator: (SavedStateHandle) -> T
-): Lazy<T> {
-    return createViewModelLazy(T::class, storeProducer = {
-        viewModelStore
-    }, factoryProducer = {
-        createAbstractSavedStateViewModelFactory(arguments ?: Bundle(), creator)
-    })
+    crossinline viewModelProducer: (SavedStateHandle) -> T
+) = viewModels<T> {
+    object : AbstractSavedStateViewModelFactory(this, arguments) {
+        override fun <T : ViewModel> create(
+            key: String, modelClass: Class<T>, handle: SavedStateHandle
+        ) = viewModelProducer(handle) as T
+    }
 }
 
-@Suppress("UNCHECKED_CAST")
 inline fun <reified T : ViewModel> Fragment.fragmentViewModels(
-    crossinline creator: () -> T
-): Lazy<T> {
-    return createViewModelLazy(T::class, storeProducer = {
-        viewModelStore
-    }, factoryProducer = {
-        object : ViewModelProvider.Factory {
-            override fun <T : ViewModel?> create(
-                modelClass: Class<T>
-            ): T = creator.invoke() as T
-        }
-    })
+    crossinline viewModelProducer: () -> T
+) = viewModels<T> {
+    object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>) = viewModelProducer() as T
+    }
 }


### PR DESCRIPTION
We can take advantage of the extensions we get out of the box from `fragment-ktx` to make things simpler for the ViewModel extensions, so that's pretty much what I'm doing here.